### PR TITLE
imageへのバリデーション

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,3 +75,4 @@ gem 'devise'
 gem 'pry-rails'
 gem 'mini_magick'
 gem 'image_processing', '~> 1.2'
+gem "active_storage_validations"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_storage_validations (1.3.0)
+      activejob (>= 6.1.4)
+      activemodel (>= 6.1.4)
+      activestorage (>= 6.1.4)
+      activesupport (>= 6.1.4)
     activejob (7.0.8.5)
       activesupport (= 7.0.8.5)
       globalid (>= 0.3.6)
@@ -245,6 +250,7 @@ PLATFORMS
   x86_64-darwin-23
 
 DEPENDENCIES
+  active_storage_validations
   bootsnap
   capybara
   debug

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -15,7 +15,7 @@ class ProfilesController < ApplicationController
     if @profile.save
       redirect_to root_path
     else
-      render : new, status: :unprocessable_entity
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -5,5 +5,5 @@ class Profile < ApplicationRecord
   belongs_to :user
   has_many :sounds
   has_many :comments
-  
+  validates :image, attached: true, content_type: ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'], size: { less_than: 500.kilobytes }
 end

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -24,17 +24,27 @@
 <main>
   <section class="profile-new">
     <h2>プロフィールを新規作成する</h2>
-    <p>プロフィールはいくつでも作成できます。楽器ごとに異なる顔を持ちましょう！</p>
+    <p>プロフィールはいくつでも作成できます。楽器ごとに異なる顔を持ちましょう！</p><br>
 
-<%= form_with model: profile, local: true do |f| %>
-      <p>画像ファイル</p>
-  <%= f.file_field :image, class: "profile-form-file" %>
-      <p>名前</p>
-  <%= f.text_field :name, class: "profile-form-name" %>
-      <p>紹介文</p>
-  <%= f.text_area :text, class: "profile-form-text" %>
-  <%= f.submit "作成する", class: "profile-form-submit" %>
-<% end %>
+    <%= form_with model: profile, local: true do |f| %>
+      <p>画像ファイル(500kb以下)</p>
+      <%= f.file_field :image, class: "profile-form-file" %>
+          <%# エラーメッセージ %>
+          <% if profile.errors[:image].any? %>
+            <div class="error-messages">
+              <% profile.errors[:image].each do |message| %>
+                <p><%= message %></p>
+              <% end %>
+            </div>
+          <% end %>
+
+      <p>名前(必須)</p>
+      <%= f.text_field :name, class: "profile-form-name" %>
+      <p>紹介文(必須)</p>
+      <%= f.text_field :text, class: "profile-form-text" %>
+      <%= f.submit "作成する", class: "profile-form-submit" %>
+    <% end %>
+  
 
   </section>
 </main>


### PR DESCRIPTION
## What
投稿画像ファイルへのバリデーション設定
(ファイルのサイズ、500k以内)

## Why
異なるファイル種類によるエラーを防ぐため。
ストレージの容量を圧迫しないため。